### PR TITLE
feat: Implement POC for Product Smart Explore section

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>商品智慧探索 POC</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>商品頁面</h1>
+    </header>
+
+    <main>
+        <section id="product-details">
+            <h2>[產品名稱]</h2>
+            <p>這裡是產品的詳細說明、價格等信息。</p>
+            <img src="https://via.placeholder.com/400x300?text=Product+Image" alt="產品圖片" style="max-width: 100%;">
+        </section>
+
+        <section id="smart-explore-section">
+            <h2>商品智慧探索</h2>
+
+            <div id="explore-view-navigator">
+                <div class="central-product-node" data-node-id="current-product">當前商品 (Product)</div>
+                <div class="explore-tags-container">
+                    <button class="explore-tag" data-tag-id="tag1">戶外機能</button>
+                    <button class="explore-tag" data-tag-id="tag2">高CP值</button>
+                    <button class="explore-tag" data-tag-id="tag3">人氣熱銷</button>
+                    <button class="explore-tag" data-tag-id="tag4">專業評測</button>
+                    <button class="explore-tag" data-tag-id="tag5">新手入門</button>
+                </div>
+            </div>
+
+            <div id="contextual-storyboard">
+                <div class="storyboard-carousel">
+                    <div class="storyboard-slides-container">
+                        <div class="storyboard-slide" style="display: block;"> <!-- Active slide -->
+                            <div class="slide-image-container">
+                                <img src="https://via.placeholder.com/600x300?text=Storyboard+Image+1" alt="情境故事板圖片1">
+                                <div class="storyboard-hotspots">
+                                    <button class="hotspot" style="top: 30%; left: 20%;">熱點1</button>
+                                    <button class="hotspot" style="top: 50%; left: 60%;">熱點2</button>
+                                </div>
+                            </div>
+                            <div class="storyboard-caption">
+                                這個故事推薦：為您的早晨增添活力，從一杯完美咖啡開始！
+                            </div>
+                        </div>
+                        <div class="storyboard-slide" style="display: none;"> <!-- Hidden slide -->
+                            <div class="slide-image-container">
+                                <img src="https://via.placeholder.com/600x300?text=Storyboard+Image+2" alt="情境故事板圖片2">
+                                <div class="storyboard-hotspots">
+                                    <button class="hotspot" style="top: 40%; left: 30%;">熱點A</button>
+                                    <button class="hotspot" style="top: 60%; left: 70%;">熱點B</button>
+                                </div>
+                            </div>
+                            <div class="storyboard-caption">
+                                這個故事推薦：探索戶外，記錄每一個精彩瞬間。
+                            </div>
+                        </div>
+                    </div>
+                    <button class="prev-slide">&#10094;</button>
+                    <button class="next-slide">&#10095;</button>
+                </div>
+            </div>
+
+            <div id="user-explore-trail">
+                <h4>我的探索足跡</h4>
+                <ul class="explore-trail-list">
+                    <li class="trail-item" data-trail-id="tagX">戶外攝影</li>
+                    <li class="trail-item" data-trail-id="tagY">防水相機包</li>
+                    <li class="trail-item" data-trail-id="tagZ">星空攝影</li>
+                </ul>
+            </div>
+
+            <div id="intelligent-qa-guide">
+                <!-- 智能問答/引導助手將在此處 -->
+                <p>智能問答/引導助手 (Intelligent Q&A/Guide) Placeholder</p>
+            </div>
+
+            <div id="community-insight">
+                <!-- 社群智慧洞察將在此處 -->
+                <p>社群智慧洞察 (Community Insight) Placeholder</p>
+            </div>
+        </section>
+    </main>
+
+    <footer>
+        <p>&copy; 2023 電商平台 POC</p>
+    </footer>
+
+    <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,220 @@
+const mockData = {
+    products: {
+        'current-product': { name: '當前商品 (Product)', relatedTags: ['tag1', 'tag2', 'tag3', 'tag4', 'tag5'] },
+    },
+    tags: {
+        'tag1': { name: '戶外機能', description: '專為戶外活動設計，注重耐用性與功能性。', storyboards: ['storyboardA', 'storyboardB'] },
+        'tag2': { name: '高CP值', description: '性價比高，兼顧品質與價格。', storyboards: ['storyboardC'] },
+        'tag3': { name: '人氣熱銷', description: '廣受好評，市場熱銷款式。', storyboards: ['storyboardA', 'storyboardC'] },
+        'tag4': { name: '專業評測', description: '經過專業人士推薦與測試。', storyboards: ['storyboardB'] },
+        'tag5': { name: '新手入門', description: '適合初學者，操作簡易。', storyboards: ['storyboardD'] },
+        // Tags previously in HTML trail, now just part of mock data if needed elsewhere or for testing
+        'tagX': { name: '戶外攝影', description: '捕捉戶外美景的攝影器材。', storyboards: ['storyboardA'] },
+        'tagY': { name: '防水相機包', description: '保護您的相機不受潮濕影響。', storyboards: ['storyboardB'] },
+        'tagZ': { name: '星空攝影', description: '拍攝美麗夜空的專用設備。', storyboards: ['storyboardC'] }
+    },
+    storyboards: {
+        'storyboardA': {
+            image: 'https://via.placeholder.com/600x300?text=Storyboard+A+(戶外)',
+            caption: '情境A：帶著裝備去山野，享受自然風光。',
+            hotspots: [{ text: '相機', top: '30%', left: '20%' }, { text: '登山杖', top: '50%', left: '60%' }]
+        },
+        'storyboardB': {
+            image: 'https://via.placeholder.com/600x300?text=Storyboard+B+(防水)',
+            caption: '情境B：雨天出行無憂，裝備全面防水。',
+            hotspots: [{ text: '防水背包', top: '40%', left: '30%' }, { text: '雨衣', top: '60%', left: '70%' }]
+        },
+        'storyboardC': {
+            image: 'https://via.placeholder.com/600x300?text=Storyboard+C+(CP值)',
+            caption: '情境C：經濟實惠，功能不打折。',
+            hotspots: [{ text: '耳機', top: '35%', left: '25%' }, { text: '行動電源', top: '55%', left: '65%' }]
+        },
+         'storyboardD': {
+            image: 'https://via.placeholder.com/600x300?text=Storyboard+D+(新手)',
+            caption: '情境D：新手友好，快速上手體驗。',
+            hotspots: [{ text: '智能手錶', top: '40%', left: '20%' }, { text: '教學書籍', top: '60%', left: '50%' }]
+        }
+    }
+};
+
+let currentTrail = [];
+const MAX_TRAIL_ITEMS = 5;
+let currentStoryboardSlideIndex = 0;
+let activeStoryboards = []; // This will hold IDs of storyboards for the current tag
+
+document.addEventListener('DOMContentLoaded', () => {
+    // Element Selectors
+    const centralProductNode = document.querySelector('.central-product-node');
+    const exploreTags = document.querySelectorAll('.explore-tag');
+    const contextualStoryboardSection = document.getElementById('contextual-storyboard');
+    const storyboardSlidesContainer = document.querySelector('.storyboard-slides-container');
+    const prevSlideButton = document.querySelector('.prev-slide');
+    const nextSlideButton = document.querySelector('.next-slide');
+    const exploreTrailList = document.querySelector('.explore-trail-list');
+
+    // Initial State
+    contextualStoryboardSection.style.display = 'none';
+    if (centralProductNode && mockData.products['current-product']) {
+      centralProductNode.textContent = mockData.products['current-product'].name;
+    }
+
+    // --- Explore View Navigator ---
+    exploreTags.forEach(tag => {
+        tag.addEventListener('click', () => {
+            const tagId = tag.dataset.tagId;
+            if (!mockData.tags[tagId]) {
+                console.error('Tag data not found for:', tagId);
+                return;
+            }
+            centralProductNode.textContent = mockData.tags[tagId].name;
+            updateContextualStoryboard(tagId);
+            addToExploreTrail(tagId);
+        });
+    });
+
+    // --- Contextual Storyboard ---
+    function updateContextualStoryboard(tagId) {
+        if (!mockData.tags[tagId] || !mockData.tags[tagId].storyboards || mockData.tags[tagId].storyboards.length === 0) {
+            contextualStoryboardSection.style.display = 'none';
+            activeStoryboards = []; // Clear active storyboards
+            return;
+        }
+        activeStoryboards = mockData.tags[tagId].storyboards;
+        contextualStoryboardSection.style.display = 'block';
+        renderStoryboards(activeStoryboards);
+    }
+
+    function renderStoryboards(storyboardIds) {
+        storyboardSlidesContainer.innerHTML = ''; // Clear existing slides
+        currentStoryboardSlideIndex = 0;
+
+        if (!storyboardIds || storyboardIds.length === 0) {
+            contextualStoryboardSection.style.display = 'none'; // Hide if no storyboards
+            return;
+        }
+        contextualStoryboardSection.style.display = 'block';
+
+
+        storyboardIds.forEach(sbId => {
+            const sbData = mockData.storyboards[sbId];
+            if (!sbData) {
+                console.error('Storyboard data not found for ID:', sbId);
+                return;
+            }
+
+            const slideDiv = document.createElement('div');
+            slideDiv.classList.add('storyboard-slide');
+            slideDiv.innerHTML = `
+                <div class="slide-image-container">
+                    <img src="${sbData.image}" alt="${sbData.caption.substring(0, 30)}...">
+                    <div class="storyboard-hotspots">
+                        ${sbData.hotspots.map(h => `<button class="hotspot" style="top: ${h.top}; left: ${h.left};" data-hotspot-text="${h.text}">${h.text}</button>`).join('')}
+                    </div>
+                </div>
+                <div class="storyboard-caption">${sbData.caption}</div>
+            `;
+            storyboardSlidesContainer.appendChild(slideDiv);
+        });
+
+        storyboardSlidesContainer.querySelectorAll('.hotspot').forEach(hotspot => {
+            hotspot.addEventListener('click', (e) => {
+                e.stopPropagation();
+                alert(`熱點 "${hotspot.dataset.hotspotText}" 被點擊!`);
+            });
+        });
+
+        if (storyboardIds.length > 0) {
+            showStoryboardSlide(0);
+        }
+    }
+
+    function showStoryboardSlide(index) {
+        const slides = storyboardSlidesContainer.querySelectorAll('.storyboard-slide');
+        if (!slides || slides.length === 0) {
+             // No slides to show, perhaps hide controls or container
+            prevSlideButton.style.display = 'none';
+            nextSlideButton.style.display = 'none';
+            return;
+        }
+
+        prevSlideButton.style.display = slides.length > 1 ? 'block' : 'none';
+        nextSlideButton.style.display = slides.length > 1 ? 'block' : 'none';
+
+        storyboardSlidesContainer.style.transform = `translateX(-${index * 100}%)`;
+        currentStoryboardSlideIndex = index;
+    }
+
+    prevSlideButton.addEventListener('click', () => {
+        if (activeStoryboards.length === 0) return;
+        let newIndex = currentStoryboardSlideIndex - 1;
+        if (newIndex < 0) {
+            newIndex = activeStoryboards.length - 1; // Loop to last
+        }
+        showStoryboardSlide(newIndex);
+    });
+
+    nextSlideButton.addEventListener('click', () => {
+        if (activeStoryboards.length === 0) return;
+        let newIndex = currentStoryboardSlideIndex + 1;
+        if (newIndex >= activeStoryboards.length) {
+            newIndex = 0; // Loop to first
+        }
+        showStoryboardSlide(newIndex);
+    });
+
+
+    // --- User Explore Trail ---
+    function addToExploreTrail(tagId) {
+        if (currentTrail.length > 0 && currentTrail[currentTrail.length - 1] === tagId) {
+            return; // Avoid adding consecutive duplicates
+        }
+
+        // If tagId is already in trail, remove it and all items after it, then add it to the end.
+        // This makes clicking an old trail item restart the trail from that point.
+        const existingIndex = currentTrail.indexOf(tagId);
+        if (existingIndex !== -1) {
+            currentTrail = currentTrail.slice(0, existingIndex);
+        }
+
+        currentTrail.push(tagId);
+        if (currentTrail.length > MAX_TRAIL_ITEMS) {
+            currentTrail.shift();
+        }
+        renderExploreTrail();
+    }
+
+    function renderExploreTrail() {
+        exploreTrailList.innerHTML = '';
+        currentTrail.forEach(tagId => {
+            if (!mockData.tags[tagId]) {
+                console.error('Tag data for trail item not found:', tagId);
+                return;
+            }
+
+            const trailItem = document.createElement('li');
+            trailItem.classList.add('trail-item');
+            trailItem.textContent = mockData.tags[tagId].name;
+            trailItem.dataset.trailId = tagId;
+
+            trailItem.addEventListener('click', () => {
+                const clickedTagId = trailItem.dataset.trailId; // Use trailItem.dataset.trailId
+                if (!mockData.tags[clickedTagId]) {
+                     console.error('Clicked trail tag data not found for:', clickedTagId);
+                     return;
+                }
+                centralProductNode.textContent = mockData.tags[clickedTagId].name;
+                updateContextualStoryboard(clickedTagId);
+
+                // When a trail item is clicked, truncate the trail up to that item and re-render.
+                const itemIndexInTrail = currentTrail.indexOf(clickedTagId);
+                if (itemIndexInTrail !== -1) {
+                    currentTrail = currentTrail.slice(0, itemIndexInTrail + 1);
+                    renderExploreTrail(); // Re-render to reflect the (potentially) truncated trail
+                }
+            });
+            exploreTrailList.appendChild(trailItem);
+        });
+    }
+
+    renderExploreTrail(); // Initial render (will be empty if currentTrail is empty)
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,324 @@
+/* --- Global Styles --- */
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f4f4f4; /* Light grey background for the page */
+    color: #333;
+    line-height: 1.6;
+}
+
+header {
+    background-color: #333;
+    color: #fff;
+    padding: 1rem 0;
+    text-align: center;
+    margin-bottom: 20px;
+}
+
+header h1 {
+    margin: 0;
+    font-size: 1.8em;
+}
+
+main {
+    max-width: 1200px;
+    margin: 0 auto; /* Center main content */
+    padding: 0 20px 60px 20px; /* Add some padding to the sides and bottom of the main content */
+}
+
+footer {
+    text-align: center;
+    padding: 1rem 0;
+    margin-top: 30px;
+    background-color: #333;
+    color: #fff;
+    font-size: 0.9em;
+    /* position: fixed; removed for now, let it be at the bottom of content */
+    /* bottom: 0; */
+    width: 100%;
+}
+
+/* --- Product Details Section --- */
+#product-details {
+    background-color: #fff;
+    padding: 20px;
+    margin-bottom: 20px;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+#product-details h2 {
+    margin-top: 0;
+    color: #333; /* Default h2 color was already #333 */
+}
+
+#product-details img { /* Already had global img style, this is to ensure it's considered */
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin-bottom: 1em;
+    border-radius: 4px; /* Slightly rounded images */
+}
+
+
+/* --- Smart Explore Section --- */
+#smart-explore-section {
+    background-color: #eef7ff; /* Unique background for the entire section */
+    padding: 20px;
+    border-radius: 8px;
+    border: 1px solid #cce0ff;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+    margin-bottom: 20px; /* Added margin for separation */
+}
+
+#smart-explore-section h2 {
+    text-align: center;
+    color: #0056b3; /* Darker blue for the section title */
+    margin-top: 0;
+    margin-bottom: 25px;
+    font-size: 1.8em;
+}
+
+/* This generic rule was making all divs inside smart-explore-section have similar styling, which is not desired anymore */
+/* #smart-explore-section div {
+    margin-bottom: 1em;
+    padding: 0.5em;
+    background-color: #e9e9e9;
+    border-left: 3px solid #007bff;
+} */
+
+/* --- Explore View Navigator --- */
+#explore-view-navigator {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+    background-color: #fff; /* Give it a background to stand out from section bg */
+    border: 1px dashed #b0c4de; /* Lighter blue dash */
+    margin-bottom: 20px;
+    min-height: 250px;
+    position: relative;
+    border-radius: 5px;
+}
+
+.central-product-node {
+    background-color: #007bff;
+    color: white;
+    padding: 15px 25px;
+    border-radius: 50px; /* Capsule shape */
+    margin-bottom: 30px; /* Space for tags */
+    font-size: 1.2em;
+    border: 2px solid #0056b3;
+}
+
+.explore-tags-container {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 15px;
+}
+
+.explore-tag {
+    background-color: #f0f0f0;
+    border: 1px solid #ddd;
+    padding: 10px 15px;
+    border-radius: 20px; /* Capsule shape */
+    cursor: pointer;
+    font-size: 0.9em;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.explore-tag:hover {
+    background-color: #007bff; /* Primary color on hover */
+    color: white;
+    transform: translateY(-2px);
+    border-color: #0056b3;
+}
+
+/* Placeholder for connecting lines - might be implemented with JS/SVG later */
+/* For POC, actual lines are optional. Could use pseudo-elements if simple. */
+
+
+/* --- Contextual Storyboard --- */
+#contextual-storyboard {
+    padding: 20px;
+    border: 1px solid #007bff;
+    background-color: #fff; /* Changed from #f9f9f9 to #fff */
+    margin-bottom: 20px;
+    border-radius: 5px;
+    /* display: none;  Will be controlled by JS later, visible for now */
+}
+
+.storyboard-carousel {
+    position: relative;
+    max-width: 700px;
+    margin: auto;
+    overflow: hidden;
+}
+
+.storyboard-slides-container {
+    display: flex;
+    /* transition: transform 0.5s ease-in-out; /* For JS slide effect */
+}
+
+.storyboard-slide {
+    min-width: 100%;
+    /* display: none; /* Controlled by JS or inline style for active */
+}
+
+.storyboard-slide .slide-image-container {
+    position: relative;
+    margin-bottom: 10px;
+}
+
+.storyboard-slide img {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    border-radius: 8px;
+}
+
+.storyboard-caption {
+    font-size: 0.95em;
+    color: #333;
+    padding: 10px;
+    text-align: center;
+    background-color: #f8f9fa; /* Light background for caption */
+    border-radius: 0 0 8px 8px;
+}
+
+.storyboard-hotspots {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+}
+
+.hotspot {
+    position: absolute;
+    background-color: rgba(0, 123, 255, 0.8);
+    color: white;
+    border: 1px solid white;
+    border-radius: 50%;
+    width: 60px;
+    height: 60px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.7em;
+    cursor: pointer;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.hotspot:hover {
+    background-color: rgba(0, 86, 179, 0.9);
+    transform: scale(1.1);
+}
+
+.prev-slide, .next-slide {
+    cursor: pointer;
+    position: absolute;
+    top: 45%; /* Adjusted for potentially taller images */
+    transform: translateY(-50%);
+    padding: 12px 16px; /* Slightly adjusted padding */
+    color: white;
+    background-color: rgba(0, 0, 0, 0.6); /* Slightly darker */
+    border: none;
+    font-weight: bold;
+    font-size: 20px; /* Larger arrows */
+    transition: background-color 0.3s ease;
+    user-select: none;
+    border-radius: 0 3px 3px 0;
+}
+
+.next-slide {
+    right: 0;
+    border-radius: 3px 0 0 3px;
+}
+
+.prev-slide:hover, .next-slide:hover {
+    background-color: rgba(0, 0, 0, 0.85);
+}
+
+
+/* --- User Explore Trail --- */
+#user-explore-trail {
+    padding: 15px;
+    border: 1px dashed #6c757d;
+    background-color: #f8f9fa;
+    margin-bottom: 20px;
+    border-radius: 5px;
+}
+
+#user-explore-trail h4 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-size: 1.1em; /* Slightly larger */
+    color: #343a40;
+}
+
+.explore-trail-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+}
+
+.trail-item {
+    background-color: #e9ecef;
+    border: 1px solid #ced4da;
+    padding: 5px 10px;
+    border-radius: 15px;
+    font-size: 0.85em;
+    color: #495057;
+    cursor: pointer;
+    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.trail-item:hover {
+    background-color: #007bff;
+    color: white;
+    border-color: #0056b3;
+}
+
+.trail-item:not(:last-child)::after {
+    content: "→";
+    margin-left: 10px;
+    color: #6c757d;
+}
+
+/* --- Intelligent Q&A / Community Insight (Placeholders) --- */
+#intelligent-qa-guide,
+#community-insight {
+    padding: 20px; /* Increased padding */
+    background-color: #fff;
+    border: 1px solid #e0e0e0; /* Lighter border */
+    margin-top: 20px;
+    border-radius: 5px;
+    text-align: center; /* Center the placeholder text */
+}
+
+/* Removed the p specific styling here to use the one from the old #explore-view-navigator p etc. */
+/* #intelligent-qa-guide p,
+#community-insight p {
+    margin: 0;
+    color: #777;
+    text-align: center;
+} */
+
+/* General Placeholder Text Style (replaces the one from line 48-55 in original) */
+#explore-view-navigator p, /* Though this one is now replaced by actual content */
+#contextual-storyboard p, /* Also replaced */
+#user-explore-trail p, /* Also replaced */
+#intelligent-qa-guide p,
+#community-insight p {
+    color: #6c757d; /* Bootstrap's text-muted color */
+    font-style: italic;
+    font-size: 0.9em;
+    margin:0; /* Ensure no extra margins on these paragraphs */
+}


### PR DESCRIPTION
This commit introduces a Proof of Concept for the "商品智慧探索" (Product Smart Explore) feature on the product detail page.

The POC includes the following components as per the PRD:
1.  **Explore View Navigator (探索視圖導航):**
    *   Displays a central product node and surrounding clickable "explore tags."
    *   Clicking a tag updates the central node and triggers other components.
2.  **Contextual Storyboard (情境故事板):**
    *   Displays context-rich slides based on the selected explore tag.
    *   Features a carousel with previous/next navigation.
    *   Includes placeholder images, captions, and clickable "hotspots" (which trigger alerts).
3.  **User Explore Trail (用戶探索足跡):**
    *   Tracks clicked explore tags, displaying them as a breadcrumb trail.
    *   Allows you to click trail items to revisit previous states.
    *   Manages trail length and avoids duplicates.

**Implementation Details:**
*   **HTML (`index.html`):** Structure for all components and placeholders.
*   **CSS (`style.css`):** Basic styling for layout, appearance, and interactivity feedback (hover effects).
*   **JavaScript (`script.js`):**
    *   Manages all interactivity.
    *   Uses mock data to simulate knowledge graph relationships and product information.
    *   Dynamically updates content in the navigator, storyboard, and trail.
*   Placeholders for "Intelligent Q&A/Guide" and "Community Insight" are included in the HTML and styled.

This POC focuses on the front-end structure, core interactions, and visual representation of the proposed features. Backend integration and advanced AI/knowledge graph functionalities are out of scope for this initial version.